### PR TITLE
I want to open the fw for port 4444

### DIFF
--- a/eu-west-1/ace/services/testinstance/terragrunt.hcl
+++ b/eu-west-1/ace/services/testinstance/terragrunt.hcl
@@ -18,5 +18,5 @@ inputs = {
   ssh_key_name     = "sshkey-tcc-ace-ec2lx"
   iam_role_name    = ""
   secgrp_name      = "fw-demo"
-  enabled_fw_ports = [ "22" ]
+  enabled_fw_ports = [ "22", "4444" ]
 }


### PR DESCRIPTION
Dear lovely infrastructure squad,
as someone responsible for "the" ETS application, I want to open tcp port 4444 in the firewall.